### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -4,25 +4,25 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-EduIntro 	KEYWORD1	EduIntro
-Led		KEYWORD1	Led
-Button		KEYWORD1	Button
+EduIntro	KEYWORD1	EduIntro
+Led	KEYWORD1	Led
+Button	KEYWORD1	Button
 Potentiometer	KEYWORD1	Potentiometer
-Piezo		KEYWORD1	Piezo
-PIR 		KEYWORD1	PIR
-DHT11 		KEYWORD1	DHT11
-LM35 		KEYWORD1	LM35
+Piezo	KEYWORD1	Piezo
+PIR	KEYWORD1	PIR
+DHT11	KEYWORD1	DHT11
+LM35	KEYWORD1	LM35
 Thermistor	KEYWORD1	Thermistor
 LightSensor	KEYWORD1	LightSensor
-MosFet		KEYWORD1	MosFet
-Relay		KEYWORD1	Relay
+MosFet	KEYWORD1	MosFet
+Relay	KEYWORD1	Relay
 ServoMotor	KEYWORD1	ServoMotor
 AnalogInput	KEYWORD1	AnalogInput
 AnalogInput2	KEYWORD1	AnalogInput2
 DigitalInput	KEYWORD1	DigitalInput
-Output		KEYWORD1	Output
-Motion		KEYWORD1	Motion
-WiFiComm 	KEYWORD1	WiFiComm
+Output	KEYWORD1	Output
+Motion	KEYWORD1	Motion
+WiFiComm	KEYWORD1	WiFiComm
 
 #######################################
 # Methods and Functions (KEYWORD2)
@@ -60,12 +60,12 @@ getClient	KEYWORD2
 #######################################
 # System Variables (KEYWORD2)
 #######################################
-acc_x   KEYWORD2
-acc_y   KEYWORD2
-acc_z   KEYWORD2
-gyro_x  KEYWORD2
-gyro_y  KEYWORD2
-gyro_z  KEYWORD2
+acc_x	KEYWORD2
+acc_y	KEYWORD2
+acc_z	KEYWORD2
+gyro_x	KEYWORD2
+gyro_y	KEYWORD2
+gyro_z	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab, the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords