### PR TITLE
Specify library dependencies in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -7,3 +7,4 @@ paragraph=Is intended to be used with Arduino UNO / MICRO / MEGA / NANO classic 
 category=Other
 url=https://arduino.cc
 architectures=*
+depends=Esplora, Arduino_LSM6DS3, WiFiNINA

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=EduIntro
-version=0.0.11
+version=0.0.12
 author=Arduino LLC
 maintainer=David Cuartielles
 sentence=Library used for super-fast introduction workshops 


### PR DESCRIPTION
Specifying the library dependencies in the `depends` field of library.properties causes Library Manager to offer to install the dependencies during installation of this library.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format