### PR TITLE
Use www subdomain in arduino.cc URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,7 +270,7 @@ Based on previous work by:
 - SimKard (DHT11), 2010
 - R. Tillaart (DHT11), 2011 - 2013
 - A. Dalton (DHT11), 2013
-- [Arduino community](https://arduino.cc)
+- [Arduino community](https://www.arduino.cc)
 
 ## Current stable version
 

--- a/library.properties
+++ b/library.properties
@@ -5,6 +5,6 @@ maintainer=David Cuartielles
 sentence=Library used for super-fast introduction workshops 
 paragraph=Is intended to be used with Arduino UNO / MICRO / MEGA / NANO classic / NANO Every / MKR / WiFi REV2 and a set of basic components (led, button, piezo, LM35, thermistor, LDR, PIR, DHT11, and servo) as a way to introduce people to the basic aspects of Arduino during short workshops. 
 category=Other
-url=https://arduino.cc
+url=https://www.arduino.cc
 architectures=*
 depends=Esplora, Arduino_LSM6DS3, WiFiNINA


### PR DESCRIPTION
www.arduino.cc is Arduino's preferred url.